### PR TITLE
implementar zoom usando brush

### DIFF
--- a/src/components/CVLineChart.jsx
+++ b/src/components/CVLineChart.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import {
   AreaChart,
   Area,
+  Brush,
   XAxis,
   YAxis,
   CartesianGrid,
@@ -14,6 +15,7 @@ import {
   formatValue,
   formatDaysSinceEpoch,
   formatDaysSinceEpochForHumans,
+  formatDaysSinceEpochShort,
 } from '../utils/formatter';
 import { daysSinceEpoch } from '../utils/daysSinceEpoch';
 
@@ -29,7 +31,8 @@ const CVLineChart = (props) => {
   const showDots = data.length < 30;
   return (
     <ResponsiveContainer>
-      <CustomChart data={chartData}>
+      <CustomChart data={chartData}
+                   margin={{left: 10}}>
         <defs>
           <linearGradient id="chartGradient" x1="0" y1="0" x2="0" y2="1">
             <stop offset="10%" stopColor="#7c97fc" stopOpacity={0.9} />
@@ -74,6 +77,14 @@ const CVLineChart = (props) => {
           fillOpacity={1}
           fill="url(#chartGradient)"
         />
+        <Brush
+          tickFormatter={() => ""}
+          height={30}
+          stroke={theme.colors.gray.normal}>
+          <AreaChart>
+            <Area dataKey="value" stroke={theme.colors.gray.light} fill={theme.colors.gray.light} dot={false} />
+          </AreaChart>
+        </Brush>
       </CustomChart>
     </ResponsiveContainer>
   );

--- a/src/components/ChartContainer.js
+++ b/src/components/ChartContainer.js
@@ -6,7 +6,7 @@ const ChartContainer = styled.div`
   align-items: center;
 
   box-sizing: border-box;
-  height: 320px;
+  height: 350px;
   width: 95%;
   @media ${({ theme }) => theme.device.laptop} {
     width: 75%;


### PR DESCRIPTION
Es muy difícil ver los valores actuales, implementé zoom usando el componente `Brush` de `Recharts`.
También arreglé la leyenda cambiando el margin-left un poco.

Después:
<img width="1120" alt="Screen Shot 2021-04-14 at 16 47 49" src="https://user-images.githubusercontent.com/32424163/114777416-a9ac2b80-9d41-11eb-9381-b43fc7619a44.png">


Antes:
<img width="1105" alt="Screen Shot 2021-04-14 at 16 47 53" src="https://user-images.githubusercontent.com/32424163/114777374-a0bb5a00-9d41-11eb-99cc-9425ca566445.png">
